### PR TITLE
Use AsRef instead of Borrow

### DIFF
--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -8,7 +8,6 @@
 //! Hash-based Message Authentication Code (HMAC).
 //!
 
-use core::borrow::Borrow;
 use core::{borrow, fmt, ops, str};
 
 use hex::DisplayHex;
@@ -212,10 +211,10 @@ impl<E: HashEngine> HmacEngine<E> {
 
         if key.len() > E::BLOCK_SIZE {
             let hash = <E as HashEngine>::hash(key);
-            for (b_i, b_h) in ipad.iter_mut().zip(hash.borrow()) {
+            for (b_i, b_h) in ipad.iter_mut().zip(hash.as_ref()) {
                 *b_i ^= *b_h;
             }
-            for (b_o, b_h) in opad.iter_mut().zip(hash.borrow()) {
+            for (b_o, b_h) in opad.iter_mut().zip(hash.as_ref()) {
                 *b_o ^= *b_h;
             }
         } else {
@@ -247,7 +246,7 @@ impl<E: HashEngine> HashEngine for HmacEngine<E> {
     #[inline]
     fn finalize(mut self) -> Self::Digest {
         let ihash = self.iengine.finalize();
-        self.oengine.input(ihash.borrow());
+        self.oengine.input(ihash.as_ref());
         self.oengine.finalize()
     }
 

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -68,7 +68,7 @@ macro_rules! hash_trait_impls {
 
         $crate::internal_macros::arr_newtype_fmt_impl!($hash, $bits / 8);
         serde_impl!($hash, $bits / 8);
-        borrow_slice_impl!($hash);
+        as_ref_impl!($hash);
 
         impl $crate::_export::_core::convert::AsRef<[u8; $bits / 8]> for $hash {
             fn as_ref(&self) -> &[u8; $bits / 8] { &self.0 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub mod sha512;
 pub mod sha512_256;
 pub mod siphash24;
 
-use core::{borrow, fmt, hash};
+use core::{convert, fmt, hash};
 
 pub use hmac::{Hmac, HmacEngine};
 
@@ -145,7 +145,7 @@ pub trait HashEngine: Clone + Default {
         + PartialOrd
         + Ord
         + hash::Hash
-        + borrow::Borrow<[u8]>;
+        + convert::AsRef<[u8]>;
 
     /// Byte array representing the internal state of the hash engine.
     type Midstate;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -126,7 +126,7 @@ pub struct Midstate(pub [u8; 32]);
 
 crate::internal_macros::arr_newtype_fmt_impl!(Midstate, 32);
 serde_impl!(Midstate, 32);
-borrow_slice_impl!(Midstate);
+as_ref_impl!(Midstate);
 
 impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
     type Output = I::Output;

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,19 +45,13 @@ macro_rules! hex_fmt_impl(
     );
 );
 
-/// Adds slicing traits implementations to a given type `$ty`
+/// Adds `AsRef` implementation to a given type `$ty`.
 #[macro_export]
-macro_rules! borrow_slice_impl(
+macro_rules! as_ref_impl(
     ($ty:ident) => (
-        $crate::borrow_slice_impl!($ty, );
+        $crate::as_ref_impl!($ty, );
     );
     ($ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::_export::_core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
-            fn borrow(&self) -> &[u8] {
-                &self[..]
-            }
-        }
-
         impl<$($gen: $gent),*> $crate::_export::_core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
                 &self[..]


### PR DESCRIPTION
The docs on `Borrow` and `AsRef` are not super clear to me but it has been suggested that we really want `AsRef<[u8]` to show that the digest is a slice of bytes not `Borrow`.