### PR TITLE
just: Remove cargo invocation

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,9 +30,6 @@ sane: lint
   # doctests don't get run from workspace root with `cargo test`.
   cargo test --quiet --workspace --doc || exit 1
 
-  # Make an attempt to catch feature gate problems in doctests
-  cargo test --manifest-path bitcoin/Cargo.toml --doc --no-default-features > /dev/null || exit 1
-
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh


### PR DESCRIPTION
This test is a copy'pasta mistake when copying the justfile from `rust-bitcoin`.