### PR TITLE
Use the now released CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,8 +33,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -57,8 +56,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -82,8 +80,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -108,8 +105,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -135,8 +131,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -159,8 +154,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1
@@ -185,8 +179,7 @@ jobs:
       - name: "Checkout maintainer tools"
         uses: actions/checkout@v4
         with:
-          repository: tcharding/rust-bitcoin-maintainer-tools
-          ref: 05-02-ci
+          repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION
The `run_task.sh` script is now released in `rust-bitcoin` maintainer tools, use it.