### PR TITLE
Rename types

### DIFF
--- a/embedded/src/main.rs
+++ b/embedded/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     loop {}
 }
 
-fn check_result(engine: sha256::HashEngine) {
+fn check_result(engine: sha256::Engine) {
     let hash = TestType::from_engine(engine);
 
     let hash_check =

--- a/extended_tests/schemars/src/main.rs
+++ b/extended_tests/schemars/src/main.rs
@@ -88,10 +88,10 @@ mod tests {
         pub struct TestHashTag;
 
         impl sha256t::Tag for TestHashTag {
-            fn engine() -> sha256::HashEngine {
+            fn engine() -> sha256::Engine {
                 // The TapRoot TapLeaf midstate.
                 let midstate = sha256::Midstate::from_byte_array(TEST_MIDSTATE);
-                sha256::HashEngine::from_midstate(midstate, 64)
+                sha256::Engine::from_midstate(midstate, 64)
             }
         }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -12,17 +12,17 @@ use core::{fmt, ops, str};
 
 use hex::DisplayHex;
 
-use crate::{FromSliceError, HashEngine};
+use crate::FromSliceError;
 
-/// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
+/// A hash computed from a RFC 2104 HMAC. Parameterized by the size of the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Hmac<const N: usize>([u8; N]);
+pub struct Hash<const N: usize>([u8; N]);
 
-impl<const N: usize> Hmac<N> {
+impl<const N: usize> Hash<N> {
     /// Returns a hash engine that is ready to be used for the data.
     pub fn engine<E>() -> E
     where
-        E: HashEngine<Digest = [u8; N]>,
+        E: crate::HashEngine<Digest = [u8; N]>,
     {
         E::new()
     }
@@ -32,7 +32,7 @@ impl<const N: usize> Hmac<N> {
     /// This is equivalent to calling `Hash::from_byte_array(engine.finalize())`.
     pub fn from_engine<E>(engine: E) -> Self
     where
-        E: HashEngine<Digest = [u8; N]>,
+        E: crate::HashEngine<Digest = [u8; N]>,
     {
         let digest = engine.finalize();
         Self::from_byte_array(digest)
@@ -88,8 +88,8 @@ impl<const N: usize> Hmac<N> {
 }
 
 #[cfg(feature = "schemars")]
-impl<const N: usize> schemars::JsonSchema for Hmac<N> {
-    fn schema_name() -> std::string::String { "Hmac".to_owned() }
+impl<const N: usize> schemars::JsonSchema for Hash<N> {
+    fn schema_name() -> std::string::String { "Hash".to_owned() }
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         let mut schema: schemars::schema::SchemaObject = <String>::json_schema(gen).into();
@@ -102,7 +102,7 @@ impl<const N: usize> schemars::JsonSchema for Hmac<N> {
     }
 }
 
-impl<const N: usize> str::FromStr for Hmac<N> {
+impl<const N: usize> str::FromStr for Hash<N> {
     type Err = hex::HexToArrayError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use hex::FromHex;
@@ -112,78 +112,78 @@ impl<const N: usize> str::FromStr for Hmac<N> {
     }
 }
 
-impl<const N: usize> fmt::Display for Hmac<N> {
+impl<const N: usize> fmt::Display for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::LowerHex::fmt(self, f) }
 }
 
-impl<const N: usize> fmt::Debug for Hmac<N> {
+impl<const N: usize> fmt::Debug for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{:#}", self) }
 }
 
-impl<const N: usize> fmt::LowerHex for Hmac<N> {
+impl<const N: usize> fmt::LowerHex for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // FIXME: Can't use hex_fmt_exact because of N.
         fmt::LowerHex::fmt(&self.0.as_hex(), f)
     }
 }
 
-impl<const N: usize> fmt::UpperHex for Hmac<N> {
+impl<const N: usize> fmt::UpperHex for Hash<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // FIXME: Can't use hex_fmt_exact because of N.
         fmt::UpperHex::fmt(&self.0.as_hex(), f)
     }
 }
-impl<const N: usize> ops::Index<usize> for Hmac<N> {
+impl<const N: usize> ops::Index<usize> for Hash<N> {
     type Output = u8;
     fn index(&self, index: usize) -> &u8 { &self.0[index] }
 }
 
-impl<const N: usize> ops::Index<ops::Range<usize>> for Hmac<N> {
+impl<const N: usize> ops::Index<ops::Range<usize>> for Hash<N> {
     type Output = [u8];
     fn index(&self, index: ops::Range<usize>) -> &[u8] { &self.0[index] }
 }
 
-impl<const N: usize> ops::Index<ops::RangeFrom<usize>> for Hmac<N> {
+impl<const N: usize> ops::Index<ops::RangeFrom<usize>> for Hash<N> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] { &self.0[index] }
 }
 
-impl<const N: usize> ops::Index<ops::RangeTo<usize>> for Hmac<N> {
+impl<const N: usize> ops::Index<ops::RangeTo<usize>> for Hash<N> {
     type Output = [u8];
     fn index(&self, index: ops::RangeTo<usize>) -> &[u8] { &self.0[index] }
 }
 
-impl<const N: usize> ops::Index<ops::RangeFull> for Hmac<N> {
+impl<const N: usize> ops::Index<ops::RangeFull> for Hash<N> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFull) -> &[u8] { &self.0[index] }
 }
 
-impl<const N: usize> AsRef<[u8]> for Hmac<N> {
+impl<const N: usize> AsRef<[u8]> for Hash<N> {
     fn as_ref(&self) -> &[u8] { &self.0 }
 }
 
 #[cfg(feature = "serde")]
-impl<const N: usize> crate::serde_macros::serde_details::SerdeHash for Hmac<N> {
+impl<const N: usize> crate::serde_macros::serde_details::SerdeHash for Hash<N> {
     const N: usize = N;
-    fn from_slice_delegated(sl: &[u8]) -> Result<Self, FromSliceError> { Hmac::from_slice(sl) }
+    fn from_slice_delegated(sl: &[u8]) -> Result<Self, FromSliceError> { Hash::from_slice(sl) }
 }
 
 #[cfg(feature = "serde")]
-impl<const N: usize> serde::Serialize for Hmac<N> {
+impl<const N: usize> serde::Serialize for Hash<N> {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         crate::serde_macros::serde_details::SerdeHash::serialize(self, s)
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de, const N: usize> crate::serde::Deserialize<'de> for Hmac<N> {
+impl<'de, const N: usize> crate::serde::Deserialize<'de> for Hash<N> {
     fn deserialize<D: crate::serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         crate::serde_macros::serde_details::SerdeHash::deserialize(d)
     }
 }
 
-/// Pair of underlying hash midstates which represent the current state of an `HmacEngine`.
-pub struct HmacMidState<E: HashEngine> {
+/// Pair of underlying hash midstates which represent the current state of an `HashEngine`.
+pub struct MidState<E: crate::HashEngine> {
     /// Midstate of the inner hash engine
     pub inner: E::Midstate,
     /// Midstate of the outer hash engine
@@ -192,16 +192,16 @@ pub struct HmacMidState<E: HashEngine> {
 
 /// Pair of underlying hash engines, used for the inner and outer hash of HMAC.
 #[derive(Clone)]
-pub struct HmacEngine<E: HashEngine> {
+pub struct HashEngine<E: crate::HashEngine> {
     iengine: E,
     oengine: E,
 }
 
-impl<E: HashEngine> Default for HmacEngine<E> {
-    fn default() -> Self { HmacEngine::new(&[]) }
+impl<E: crate::HashEngine> Default for HashEngine<E> {
+    fn default() -> Self { HashEngine::new(&[]) }
 }
 
-impl<E: HashEngine> HmacEngine<E> {
+impl<E: crate::HashEngine> HashEngine<E> {
     /// Constructs a new keyed HMAC from `key`.
     ///
     /// We only support hash engines whose internal block sizes are ≤ 128 bytes.
@@ -209,15 +209,15 @@ impl<E: HashEngine> HmacEngine<E> {
     /// # Panics
     ///
     /// Larger block sizes will result in a panic.
-    pub fn new(key: &[u8]) -> HmacEngine<E> {
+    pub fn new(key: &[u8]) -> HashEngine<E> {
         debug_assert!(E::BLOCK_SIZE <= 128);
 
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
-        let mut ret = HmacEngine { iengine: E::default(), oengine: E::default() };
+        let mut ret = HashEngine { iengine: E::default(), oengine: E::default() };
 
         if key.len() > E::BLOCK_SIZE {
-            let hash = <E as HashEngine>::hash(key);
+            let hash = <E as crate::HashEngine>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(hash.as_ref()) {
                 *b_i ^= *b_h;
             }
@@ -239,9 +239,9 @@ impl<E: HashEngine> HmacEngine<E> {
     }
 }
 
-impl<E: HashEngine> HashEngine for HmacEngine<E> {
+impl<E: crate::HashEngine> crate::HashEngine for HashEngine<E> {
     type Digest = E::Digest;
-    type Midstate = HmacMidstate<E>;
+    type Midstate = Midstate<E>;
     const BLOCK_SIZE: usize = E::BLOCK_SIZE;
 
     #[inline]
@@ -259,22 +259,22 @@ impl<E: HashEngine> HashEngine for HmacEngine<E> {
 
     #[inline]
     fn midstate(&self) -> Self::Midstate {
-        HmacMidstate { inner: self.iengine.midstate(), outer: self.oengine.midstate() }
+        Midstate { inner: self.iengine.midstate(), outer: self.oengine.midstate() }
     }
 
     #[inline]
-    fn from_midstate(midstate: HmacMidstate<E>, length: usize) -> Self {
-        HmacEngine {
+    fn from_midstate(midstate: Midstate<E>, length: usize) -> Self {
+        HashEngine {
             iengine: E::from_midstate(midstate.inner, length),
             oengine: E::from_midstate(midstate.outer, length),
         }
     }
 }
 
-/// Pair of underlying hash engine midstates which represent the current state of an `HmacEngine`.
+/// Pair of underlying hash engine midstates which represent the current state of an `HashEngine`.
 // TODO: Use derives?
 //#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct HmacMidstate<E: HashEngine> {
+pub struct Midstate<E: crate::HashEngine> {
     /// Midstate of the inner hash engine.
     pub inner: E::Midstate,
     /// Midstate of the outer hash engine.
@@ -402,7 +402,7 @@ mod tests {
         ];
 
         for test in tests {
-            let mut engine = HmacEngine::<sha256::HashEngine>::new(&test.key);
+            let mut engine = HashEngine::<sha256::HashEngine>::new(&test.key);
             engine.input(&test.input);
             let hash = engine.finalize();
             assert_eq!(&hash[..], &test.output[..]);
@@ -413,9 +413,8 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn hmac_sha512_serde() {
+        use crate::hmac;
         use serde_test::{assert_tokens, Configure, Token};
-
-        use crate::Hmac;
 
         #[rustfmt::skip]
         static HASH_BYTES: [u8; 64] = [
@@ -429,7 +428,7 @@ mod tests {
             0x0b, 0x2d, 0x8a, 0x60, 0x0b, 0xdf, 0x4c, 0x0c,
         ];
 
-        let hash = Hmac::<64>::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let hash = hmac::Hash::<64>::from_slice(&HASH_BYTES).expect("right number of bytes");
 
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
         assert_tokens(
@@ -446,8 +445,8 @@ mod tests {
         use super::*;
         use crate::sha256;
 
-        let engine: HmacEngine<sha256::HashEngine> = Default::default();
-        let hmac = Hmac::from_engine(engine);
+        let engine: HashEngine<sha256::HashEngine> = Default::default();
+        let hmac = Hash::from_engine(engine);
         let hint = hmac.0.iter().size_hint().1;
 
         println!("hint: {:?}", hint);
@@ -458,11 +457,11 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use crate::{sha256, HashEngine, HmacEngine};
+    use crate::{sha256, HashEngine, HashEngine};
 
     #[bench]
     pub fn hmac_sha256_10(bh: &mut Bencher) {
-        let mut engine: HmacEngine<sha256::HashEngine> = Default::default();
+        let mut engine: HashEngine<sha256::HashEngine> = Default::default();
         let bytes = [1u8; 10];
         bh.iter(|| {
             engine.input(&bytes);
@@ -472,7 +471,7 @@ mod benches {
 
     #[bench]
     pub fn hmac_sha256_1k(bh: &mut Bencher) {
-        let mut engine: HmacEngine<sha256::HashEngine> = Default::default();
+        let mut engine: HashEngine<sha256::HashEngine> = Default::default();
         let bytes = [1u8; 1024];
         bh.iter(|| {
             engine.input(&bytes);
@@ -482,7 +481,7 @@ mod benches {
 
     #[bench]
     pub fn hmac_sha256_64k(bh: &mut Bencher) {
-        let mut engine: HmacEngine<sha256::HashEngine> = Default::default();
+        let mut engine: HashEngine<sha256::HashEngine> = Default::default();
         let bytes = [1u8; 65536];
         bh.iter(|| {
             engine.input(&bytes);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,11 +7,11 @@
 
 use bitcoin_io::impl_write;
 
-use crate::{hmac, ripemd160, sha1, sha256, sha256t, sha512, siphash24, HashEngine as _};
+use crate::{hmac, ripemd160, sha1, sha256, sha256t, sha512, siphash24, HashEngine};
 
 impl_write!(
-    sha1::HashEngine,
-    |us: &mut sha1::HashEngine, buf| {
+    sha1::Engine,
+    |us: &mut sha1::Engine, buf| {
         us.input(buf);
         Ok(buf.len())
     },
@@ -19,8 +19,8 @@ impl_write!(
 );
 
 impl_write!(
-    sha256::HashEngine,
-    |us: &mut sha256::HashEngine, buf| {
+    sha256::Engine,
+    |us: &mut sha256::Engine, buf| {
         us.input(buf);
         Ok(buf.len())
     },
@@ -28,8 +28,8 @@ impl_write!(
 );
 
 impl_write!(
-    sha512::HashEngine,
-    |us: &mut sha512::HashEngine, buf| {
+    sha512::Engine,
+    |us: &mut sha512::Engine, buf| {
         us.input(buf);
         Ok(buf.len())
     },
@@ -37,8 +37,8 @@ impl_write!(
 );
 
 impl_write!(
-    ripemd160::HashEngine,
-    |us: &mut ripemd160::HashEngine, buf| {
+    ripemd160::Engine,
+    |us: &mut ripemd160::Engine, buf| {
         us.input(buf);
         Ok(buf.len())
     },
@@ -46,18 +46,17 @@ impl_write!(
 );
 
 impl_write!(
-    siphash24::HashEngine,
-    |us: &mut siphash24::HashEngine, buf| {
+    siphash24::Engine,
+    |us: &mut siphash24::Engine, buf| {
         us.input(buf);
         Ok(buf.len())
     },
     |_us| { Ok(()) }
 );
 
-impl<E: crate::HashEngine> bitcoin_io::Write for hmac::HashEngine<E> {
+impl<E: HashEngine> bitcoin_io::Write for hmac::Engine<E> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, bitcoin_io::Error> {
-        use crate::HashEngine as _;
         self.input(buf);
         Ok(buf.len())
     }
@@ -67,7 +66,7 @@ impl<E: crate::HashEngine> bitcoin_io::Write for hmac::HashEngine<E> {
 }
 
 #[cfg(feature = "std")]
-impl<E: crate::HashEngine> std::io::Write for hmac::HashEngine<E> {
+impl<E: HashEngine> std::io::Write for hmac::Engine<E> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.input(buf);
@@ -79,8 +78,8 @@ impl<E: crate::HashEngine> std::io::Write for hmac::HashEngine<E> {
 }
 
 impl_write!(
-    sha256t::HashEngine<T>,
-    |us: &mut sha256t::HashEngine<T>, buf| {
+    sha256t::Engine<T>,
+    |us: &mut sha256t::Engine<T>, buf| {
         us.input(buf);
         Ok(buf.len())
     },
@@ -98,17 +97,17 @@ mod tests {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {
             #[test]
             fn $mod() {
-                let mut engine = $mod::HashEngine::new();
+                let mut engine = $mod::Engine::new();
                 engine.write_all(&[]).unwrap();
                 let hash = $mod::Hash::from_engine(engine);
                 assert_eq!(format!("{}", hash), $exp_empty);
 
-                let mut engine = $mod::HashEngine::new();
+                let mut engine = $mod::Engine::new();
                 engine.write_all(&[1; 256]).unwrap();
                 let hash = $mod::Hash::from_engine(engine);
                 assert_eq!(format!("{}", hash), $exp_256);
 
-                let mut engine = $mod::HashEngine::new();
+                let mut engine = $mod::Engine::new();
                 engine.write_all(&[99; 64000]).unwrap();
                 let hash = $mod::Hash::from_engine(engine);
                 assert_eq!(format!("{}", hash), $exp_64k);
@@ -151,21 +150,21 @@ mod tests {
 
     #[test]
     fn hmac() {
-        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::Engine::<sha256::Engine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[]).unwrap();
         assert_eq!(
             format!("{}", hmac::Hash::from_engine(engine)),
             "bf5515149cf797955c4d3194cca42472883281951697c8375d9d9b107f384225"
         );
 
-        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::Engine::<sha256::Engine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[1; 256]).unwrap();
         assert_eq!(
             format!("{}", hmac::Hash::from_engine(engine)),
             "59c9aca10c81c73cb4c196d94db741b6bf2050e0153d5a45f2526bff34675ac5"
         );
 
-        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::Engine::<sha256::Engine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[99; 64000]).unwrap();
         assert_eq!(
             format!("{}", hmac::Hash::from_engine(engine)),

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,7 +7,7 @@
 
 use bitcoin_io::impl_write;
 
-use crate::{ripemd160, sha1, sha256, sha256t, sha512, siphash24, HashEngine, HmacEngine};
+use crate::{hmac, ripemd160, sha1, sha256, sha256t, sha512, siphash24, HashEngine as _};
 
 impl_write!(
     sha1::HashEngine,
@@ -54,7 +54,7 @@ impl_write!(
     |_us| { Ok(()) }
 );
 
-impl<E: HashEngine> bitcoin_io::Write for HmacEngine<E> {
+impl<E: crate::HashEngine> bitcoin_io::Write for hmac::HashEngine<E> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, bitcoin_io::Error> {
         use crate::HashEngine as _;
@@ -67,7 +67,7 @@ impl<E: HashEngine> bitcoin_io::Write for HmacEngine<E> {
 }
 
 #[cfg(feature = "std")]
-impl<E: HashEngine> std::io::Write for HmacEngine<E> {
+impl<E: crate::HashEngine> std::io::Write for hmac::HashEngine<E> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.input(buf);
@@ -92,7 +92,7 @@ impl_write!(
 mod tests {
     use bitcoin_io::Write;
 
-    use crate::{ripemd160, sha1, sha256, sha512, siphash24, HashEngine as _, Hmac, HmacEngine};
+    use crate::{hmac, ripemd160, sha1, sha256, sha512, siphash24, HashEngine as _};
 
     macro_rules! write_test {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {
@@ -151,24 +151,24 @@ mod tests {
 
     #[test]
     fn hmac() {
-        let mut engine = HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[]).unwrap();
         assert_eq!(
-            format!("{}", Hmac::from_engine(engine)),
+            format!("{}", hmac::Hash::from_engine(engine)),
             "bf5515149cf797955c4d3194cca42472883281951697c8375d9d9b107f384225"
         );
 
-        let mut engine = HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[1; 256]).unwrap();
         assert_eq!(
-            format!("{}", Hmac::from_engine(engine)),
+            format!("{}", hmac::Hash::from_engine(engine)),
             "59c9aca10c81c73cb4c196d94db741b6bf2050e0153d5a45f2526bff34675ac5"
         );
 
-        let mut engine = HmacEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut engine = hmac::HashEngine::<sha256::HashEngine>::new(&[0xde, 0xad, 0xbe, 0xef]);
         engine.write_all(&[99; 64000]).unwrap();
         assert_eq!(
-            format!("{}", Hmac::from_engine(engine)),
+            format!("{}", hmac::Hash::from_engine(engine)),
             "30df499717415a395379a1eaabe50038036e4abb5afc94aa55c952f4aa57be08"
         );
     }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -21,14 +21,14 @@ macro_rules! engine_input_impl(
         #[cfg(not(hashes_fuzz))]
         fn input(&mut self, mut inp: &[u8]) {
             while !inp.is_empty() {
-                let buf_idx = self.length % <Self as crate::HashEngine>::BLOCK_SIZE;
-                let rem_len = <Self as crate::HashEngine>::BLOCK_SIZE - buf_idx;
+                let buf_idx = self.length % <Self as $crate::HashEngine>::BLOCK_SIZE;
+                let rem_len = <Self as $crate::HashEngine>::BLOCK_SIZE - buf_idx;
                 let write_len = $crate::_export::_core::cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len]
                     .copy_from_slice(&inp[..write_len]);
                 self.length += write_len;
-                if self.length % <Self as crate::HashEngine>::BLOCK_SIZE == 0 {
+                if self.length % <Self as $crate::HashEngine>::BLOCK_SIZE == 0 {
                     self.process_block();
                 }
                 inp = &inp[write_len..];
@@ -187,7 +187,7 @@ macro_rules! hash_type {
             }
 
             /// Copies a byte slice into a hash object.
-            pub fn from_slice(sl: &[u8]) -> Result<Self, crate::FromSliceError> {
+            pub fn from_slice(sl: &[u8]) -> Result<Self, $crate::FromSliceError> {
                 if sl.len() != $bits / 8 {
                     Err(crate::FromSliceError { expected: $bits / 8, got: sl.len() })
                 } else {
@@ -239,7 +239,7 @@ macro_rules! hash_type {
             }
         }
 
-        crate::internal_macros::hash_trait_impls!($bits);
+        $crate::internal_macros::hash_trait_impls!($bits);
     };
 }
 pub(crate) use hash_type;

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -162,12 +162,12 @@ macro_rules! hash_type {
             }
 
             /// Returns a hash engine that is ready to be used for data.
-            pub fn engine() -> HashEngine { HashEngine::new() }
+            pub fn engine() -> Engine { Engine::new() }
 
             /// Creates a `Hash` from an `engine`.
             ///
             /// This is equivalent to calling `Hash::from_byte_array(engine.finalize())`.
-            pub fn from_engine(engine: HashEngine) -> Self {
+            pub fn from_engine(engine: Engine) -> Self {
                 let digest = engine.finalize();
                 Self(digest)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,6 @@ pub mod siphash24;
 
 use core::{convert, fmt, hash};
 
-pub use hmac::{Hmac, HmacEngine};
-
 /// A hashing engine which bytes can be serialized into.
 pub trait HashEngine: Clone + Default {
     /// The digest returned by this hash engine.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! #[cfg(std)]
 //! # fn main() -> std::io::Result<()> {
 //! let mut reader: &[u8] = b"hello"; // in real code, this could be a `File` or `TcpStream`
-//! let mut engine = sha256::HashEngine::default();
+//! let mut engine = sha256::Engine::default();
 //! std::io::copy(&mut reader, &mut engine)?;
 //! let hash = sha256::Hash::from_engine(engine);
 //! # Ok(())
@@ -58,7 +58,7 @@
 //! let mut part1: &[u8] = b"hello";
 //! let mut part2: &[u8] = b" ";
 //! let mut part3: &[u8] = b"world";
-//! let mut engine = sha256::HashEngine::default();
+//! let mut engine = sha256::Engine::default();
 //! engine.write_all(part1)?;
 //! engine.write_all(part2)?;
 //! engine.write_all(part3)?;

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -4,7 +4,7 @@
 
 use core::str;
 
-use crate::HashEngine as _;
+use crate::HashEngine;
 
 crate::internal_macros::hash_type! {
     160,
@@ -15,15 +15,15 @@ const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute RIPEMD160 hash function.
 #[derive(Clone)]
-pub struct HashEngine {
+pub struct Engine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
 }
 
-impl Default for HashEngine {
+impl Default for Engine {
     fn default() -> Self {
-        HashEngine {
+        Engine {
             h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
             length: 0,
             buffer: [0; BLOCK_SIZE],
@@ -31,7 +31,7 @@ impl Default for HashEngine {
     }
 }
 
-impl crate::HashEngine for HashEngine {
+impl HashEngine for Engine {
     type Digest = [u8; 20];
     type Midstate = [u8; 20];
     const BLOCK_SIZE: usize = BLOCK_SIZE;
@@ -87,7 +87,7 @@ impl crate::HashEngine for HashEngine {
     }
 
     #[inline]
-    fn from_midstate(midstate: Self::Midstate, length: usize) -> HashEngine {
+    fn from_midstate(midstate: Self::Midstate, length: usize) -> Engine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
         let mut ret = [0; 5];
@@ -95,7 +95,7 @@ impl crate::HashEngine for HashEngine {
             *ret_val = u32::from_be_bytes(midstate_bytes.try_into().expect("4 byte slice"));
         }
 
-        HashEngine { buffer: [0; BLOCK_SIZE], h: ret, length }
+        Engine { buffer: [0; BLOCK_SIZE], h: ret, length }
     }
 }
 
@@ -224,7 +224,7 @@ macro_rules! process_block(
     });
 );
 
-impl HashEngine {
+impl Engine {
     fn process_block(&mut self) {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
@@ -504,7 +504,7 @@ mod tests {
             );
 
             // Hash through engine, checking that we can input byte by byte
-            let mut engine = ripemd160::HashEngine::new();
+            let mut engine = ripemd160::Engine::new();
             for ch in test.input.as_bytes() {
                 engine.input(&[*ch]);
             }

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -4,7 +4,7 @@
 
 use core::str;
 
-use crate::HashEngine as _;
+use crate::HashEngine;
 
 crate::internal_macros::hash_type! {
     160,
@@ -15,15 +15,15 @@ const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA-1 hash function.
 #[derive(Clone)]
-pub struct HashEngine {
+pub struct Engine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
 }
 
-impl Default for HashEngine {
+impl Default for Engine {
     fn default() -> Self {
-        HashEngine {
+        Engine {
             h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
             length: 0,
             buffer: [0; BLOCK_SIZE],
@@ -31,7 +31,7 @@ impl Default for HashEngine {
     }
 }
 
-impl crate::HashEngine for HashEngine {
+impl HashEngine for Engine {
     type Digest = [u8; 20];
     type Midstate = [u8; 20];
     const BLOCK_SIZE: usize = BLOCK_SIZE;
@@ -79,7 +79,7 @@ impl crate::HashEngine for HashEngine {
     }
 
     #[inline]
-    fn from_midstate(midstate: Self::Midstate, length: usize) -> HashEngine {
+    fn from_midstate(midstate: Self::Midstate, length: usize) -> Engine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
         let mut ret = [0; 5];
@@ -87,11 +87,11 @@ impl crate::HashEngine for HashEngine {
             *ret_val = u32::from_be_bytes(midstate_bytes.try_into().expect("4 byte slice"));
         }
 
-        HashEngine { buffer: [0; BLOCK_SIZE], h: ret, length }
+        Engine { buffer: [0; BLOCK_SIZE], h: ret, length }
     }
 }
 
-impl HashEngine {
+impl Engine {
     // Basic unoptimized algorithm from Wikipedia
     fn process_block(&mut self) {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
@@ -197,7 +197,7 @@ mod tests {
             assert_eq!(&hash.to_string(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
-            let mut engine = sha1::HashEngine::new();
+            let mut engine = sha1::Engine::new();
             for ch in test.input.as_bytes() {
                 engine.input(&[*ch]);
             }

--- a/src/sha384.rs
+++ b/src/sha384.rs
@@ -4,7 +4,7 @@
 
 use core::str;
 
-use crate::{sha512, HashEngine as _};
+use crate::{sha512, HashEngine};
 
 crate::internal_macros::hash_type! {
     384,
@@ -13,16 +13,16 @@ crate::internal_macros::hash_type! {
 
 /// Engine to compute SHA-384 hash function.
 #[derive(Clone)]
-pub struct HashEngine(sha512::HashEngine);
+pub struct Engine(sha512::Engine);
 
-impl Default for HashEngine {
+impl Default for Engine {
     #[rustfmt::skip]
     fn default() -> Self {
-        HashEngine(sha512::HashEngine::sha384())
+        Engine(sha512::Engine::sha384())
     }
 }
 
-impl crate::HashEngine for HashEngine {
+impl HashEngine for Engine {
     type Digest = [u8; 48];
     type Midstate = [u8; 64]; // SHA-512 midstate.
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
@@ -44,8 +44,8 @@ impl crate::HashEngine for HashEngine {
     fn midstate(&self) -> [u8; 64] { self.0.midstate() }
 
     #[inline]
-    fn from_midstate(midstate: [u8; 64], length: usize) -> HashEngine {
-        HashEngine(sha512::HashEngine::from_midstate(midstate, length))
+    fn from_midstate(midstate: [u8; 64], length: usize) -> Engine {
+        Engine(sha512::Engine::from_midstate(midstate, length))
     }
 }
 

--- a/src/sha512_256.rs
+++ b/src/sha512_256.rs
@@ -9,7 +9,7 @@
 
 use core::str;
 
-use crate::{sha512, HashEngine as _};
+use crate::{sha512, HashEngine};
 
 crate::internal_macros::hash_type! {
     256,
@@ -23,16 +23,16 @@ crate::internal_macros::hash_type! {
 /// produces an entirely different hash compared to sha512. More information at
 /// <https://eprint.iacr.org/2010/548.pdf>.
 #[derive(Clone)]
-pub struct HashEngine(sha512::HashEngine);
+pub struct Engine(sha512::Engine);
 
-impl Default for HashEngine {
+impl Default for Engine {
     #[rustfmt::skip]
     fn default() -> Self {
-        HashEngine(sha512::HashEngine::sha512_256())
+        Engine(sha512::Engine::sha512_256())
     }
 }
 
-impl crate::HashEngine for HashEngine {
+impl HashEngine for Engine {
     type Digest = [u8; 32];
     type Midstate = [u8; 64]; // SHA-512 midstate.
     const BLOCK_SIZE: usize = sha512::BLOCK_SIZE;
@@ -55,8 +55,8 @@ impl crate::HashEngine for HashEngine {
     fn midstate(&self) -> [u8; 64] { self.0.midstate() }
 
     #[inline]
-    fn from_midstate(midstate: [u8; 64], length: usize) -> HashEngine {
-        HashEngine(sha512::HashEngine::from_midstate(midstate, length))
+    fn from_midstate(midstate: [u8; 64], length: usize) -> Engine {
+        Engine(sha512::Engine::from_midstate(midstate, length))
     }
 }
 


### PR DESCRIPTION
Done in two parts:

- Rename the `Hmac` and `HmacEngine` types to `Hash` and `HashEngine`
- Rename all the `HashEngine` types to plain old `Engine`

(Patch 1 is a trivial cleanup.)