### PR TITLE
Bump version to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0 - 2024-05-14
+
+* Rename `HashEngine` types to `Engine` [#10](https://github.com/tcharding/rust-chf/pull/10).
+* Also, rename `Hmac` and `HmacEngine` to be `hmac::Hash` and `hmac::Engine` respectively.
+
 # 0.2.1 - 2024-05-14
 
 * Update the README file to mention tagged hash module added in 0.2.0 release.

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -16,7 +16,7 @@ checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
 name = "chf"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -16,7 +16,7 @@ checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
 name = "chf"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chf"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 # TODO: Move this crate to `github.com/rust-bitcoin`.


### PR DESCRIPTION
In preparation for release add a changelog entry, update the lock files, and bump the version number.